### PR TITLE
prevent creation of tx inputs exceeding max-money

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1172,6 +1172,12 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                     scriptChange = pcoin.first->vout[pcoin.second].scriptPubKey;
                 }
 
+		/* the following prevents creating a transaction where inputs accumulate over MAX_MONEY
+		 it would be useful to display an informational error message describing the situation
+        */
+                if (nValueIn > ((int)nBestHeight > FORK_HEIGHT ? MAX_MONEY_2 : MAX_MONEY))
+                return error("Transaction creation failed : total inputs exceed MAX_MONEY");  
+                
                 int64 nChange = nValueIn - nValue - nFeeRet;
                 // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
                 // or until nChange becomes zero


### PR DESCRIPTION
still possible to exceed max-money using rawtransactions